### PR TITLE
Add character limit to quote submissions

### DIFF
--- a/app/settings.py
+++ b/app/settings.py
@@ -4,7 +4,6 @@ One unified place to hold configurations for the application.
 """
 
 import typing
-import sentry_sdk 
 from starlette.middleware import Middleware
 from starlette.middleware.cors import CORSMiddleware
 from sentry_sdk.integrations.asgi import SentryAsgiMiddleware
@@ -12,12 +11,12 @@ from sentry_sdk.integrations.asgi import SentryAsgiMiddleware
 from app import utils
 
 
-# Initialize the Sentry SDK.
-sentry_sdk.init(dsn=utils.config("SENTRY_DSN", default=None))
-
-
 # Load whether or not to run the application in debug mode from config.
 DEBUG = utils.config("DEBUG", cast=bool, default=False)
+
+
+# Maximum number of characters allowed for a quote.
+QUOTE_MAX_CHARACTERS = 140
 
 
 # Load any middleware to run with the application.

--- a/app/utils.py
+++ b/app/utils.py
@@ -5,6 +5,7 @@ Functions and classes to help the application.
 
 import aiohttp
 import aioredis
+import sentry_sdk
 from starlette.config import Config
 
 
@@ -31,6 +32,9 @@ async def lifespan(app):
   In this case we want a connection to Redis to persist throughout the lifespan 
   of the app.
   """
+
+  # Initialize the Sentry SDK.
+  sentry_sdk.init(dsn=config("SENTRY_DSN", default=None))
 
   # Create the Redis connection.
   url = config("REDIS_URL")


### PR DESCRIPTION
### Issue reference

Closes #11.

### Description of the change

Enforces a character limit on submitted quotes, controlled by the new setting `QUOTE_MAX_CHARACTERS`. I've also done a small amount of code refactor and fixed one issue where the server would crash if you send a post request to `/submit` with no request body.

### Additional context

Request:
```
curl --location --request POST 'http://localhost:8000/submit' \
--header 'Authorization: Bearer bungus' \
--header 'Content-Type: application/json' \
--data-raw '{
    "quote": "Hello this is a quote that is far too long to be submitted so it is not allowed to be submitted to this platform hello there are wayyyyy too many characters in this quote hahahaha lol isn'\''t this super funny lolmaorofl"
}'
```

Response:
```json
{
    "message": "Quote is too long. Must be maximum 140 characters.",
    "data": {
        "quote": "Hello this is a quote that is far too long to be submitted so it is not allowed to be submitted to this platform hello there are wayyyyy too many characters in this quote hahahaha lol isn't this super funny lolmaorofl",
        "length": 217
    }
}
```